### PR TITLE
Get User's Active Rides 

### DIFF
--- a/src/person/serializers.py
+++ b/src/person/serializers.py
@@ -52,11 +52,7 @@ class UserSerializer(serializers.ModelSerializer):
 
     def get_rides(self, user):
         rides = user.person.driver.all() | user.person.ride_set.all()
-        results = []
-        for ride in rides:
-            serialized = SimpleRideSerializer(ride)
-            results.append(serialized.data)
-        return results
+        return [SimpleRideSerializer(ride).data for ride in rides]
 
     class Meta:
         model = User

--- a/src/person/serializers.py
+++ b/src/person/serializers.py
@@ -3,6 +3,7 @@ import json
 from django.contrib.auth.models import User
 from rest_framework import serializers
 from rest_framework.fields import SerializerMethodField
+from ride.simple_serializers import SimpleRideSerializer
 
 
 class AuthenticateSerializer(serializers.ModelSerializer):
@@ -29,6 +30,7 @@ class UserSerializer(serializers.ModelSerializer):
     profile_pic_url = serializers.CharField(source="person.profile_pic_url")
     phone_number = serializers.CharField(source="person.phone_number")
     prompts = SerializerMethodField("get_prompts")
+    rides = SerializerMethodField("get_rides")
 
     def get_prompts(self, user):
         prompt_questions = user.person.prompt_questions.all()
@@ -48,6 +50,14 @@ class UserSerializer(serializers.ModelSerializer):
             )
         return prompts
 
+    def get_rides(self, user):
+        rides = user.person.driver.all() | user.person.ride_set.all()
+        results = []
+        for ride in rides:
+            serialized = SimpleRideSerializer(ride)
+            results.append(serialized.data)
+        return results
+
     class Meta:
         model = User
         fields = (
@@ -60,5 +70,6 @@ class UserSerializer(serializers.ModelSerializer):
             "profile_pic_url",
             "pronouns",
             "prompts",
+            "rides",
         )
         read_only_fields = fields


### PR DESCRIPTION
## Overview

Currently, there is no way to get a user's active rides (rides they are either driving or riding in). Include active rides as a field when getting a user. 

## Changes Made

- Modify UserSerializer to include active rides 


## Test Coverage

Manual testing via Postman 

## /api/me/ - GET
Sample Response: 
```
{
    "id": 2,
    "netid": "ksl67",
    "first_name": "Kate",
    "last_name": "Liang",
    "phone_number": "1234567890",
    "grade": "2024",
    "profile_pic_url": null,
    "pronouns": "she/her",
    "prompts": [
        {
            "id": 1,
            "question_name": "Favorite food",
            "question_placeholder": "Ramen",
            "answer": "rice cake"
        },
        {
            "id": 2,
            "question_name": "Favorite song",
            "question_placeholder": "Rich Flex",
            "answer": "heat waves"
        }
    ],
    "rides": [
        {
            "id": 1,
            "departure_datetime": "2020-03-27T00:00:00Z",
            "path": {
                "id": 1,
                "start_location_place_id": "teststartid",
                "start_location_name": "cornell",
                "end_location_place_id": "testendid",
                "end_location_name": "syracuse"
            },
            "type": "rideshare"
        },
        {
            "id": 2,
            "departure_datetime": "2020-03-27T00:00:00Z",
            "path": {
                "id": 1,
                "start_location_place_id": "teststartid",
                "start_location_name": "cornell",
                "end_location_place_id": "testendid",
                "end_location_name": "syracuse"
            },
            "type": "rideshare"
        }
    ]
}
```
