### PR TITLE
Standardize timezone in app

### DIFF
--- a/src/person/serializers.py
+++ b/src/person/serializers.py
@@ -59,10 +59,11 @@ class UserSerializer(serializers.ModelSerializer):
             | user.person.creator.all()
         )
         rides = sorted(rides, key=lambda ride: ride.id)
-        # TODO: Write script that deletes non-active rides from DB
         for ride in rides:
             if ride.departure_datetime >= timezone.now():
                 active_rides.add(ride)
+            else:
+                ride.delete()
         return [SimpleRideSerializer(ride).data for ride in active_rides]
 
     class Meta:

--- a/src/request/controllers/update_request_controller.py
+++ b/src/request/controllers/update_request_controller.py
@@ -1,9 +1,8 @@
-from datetime import datetime
-
 from api.utils import failure_response
 from api.utils import success_response
 from api.utils import update
 from django.core.exceptions import ObjectDoesNotExist
+from django.utils import timezone
 from person.models import Person
 from ride.models import Ride
 
@@ -43,7 +42,7 @@ class UpdateRequestController:
             ride.save()
 
         # If approved is not None or ride's departure deadline has passed, delete request
-        if approved is not None or ride.departure_datetime < datetime.now():
+        if approved is not None or ride.departure_datetime < timezone.now():
             Request.objects.filter(id=self._id).delete()
 
         # Save new changes

--- a/src/ride/controllers/search_ride_controller.py
+++ b/src/ride/controllers/search_ride_controller.py
@@ -5,6 +5,7 @@ from api.utils import failure_response
 from api.utils import success_response
 import geopy.distance
 import requests
+import zoneinfo
 
 from ..models import Path
 from ..models import Ride
@@ -60,9 +61,10 @@ class SearchRideController:
             ):
                 paths.append(path)
 
+        tz = zoneinfo.ZoneInfo("America/New_York")
         departure_datetime_object = datetime.datetime.fromisoformat(
             departure_datetime
-        ).astimezone()
+        ).astimezone(tz)
 
         departure_yesterday = departure_datetime_object - datetime.timedelta(days=1)
         departure_tomorrow = departure_datetime_object + datetime.timedelta(days=1)

--- a/src/ride/controllers/search_ride_controller.py
+++ b/src/ride/controllers/search_ride_controller.py
@@ -5,6 +5,7 @@ from api.utils import failure_response
 from api.utils import success_response
 import geopy.distance
 import requests
+from rideshare.settings import TIME_ZONE
 import zoneinfo
 
 from ..models import Path
@@ -61,7 +62,7 @@ class SearchRideController:
             ):
                 paths.append(path)
 
-        tz = zoneinfo.ZoneInfo("America/New_York")
+        tz = zoneinfo.ZoneInfo(TIME_ZONE)
         departure_datetime_object = datetime.datetime.fromisoformat(
             departure_datetime
         ).astimezone(tz)

--- a/src/rideshare/settings.py
+++ b/src/rideshare/settings.py
@@ -130,7 +130,7 @@ AUTH_PASSWORD_VALIDATORS = [
 
 LANGUAGE_CODE = "en-us"
 
-TIME_ZONE = "UTC"
+TIME_ZONE = "America/New_York"
 
 USE_I18N = True
 


### PR DESCRIPTION
## Overview

Currently, the datetime used across the app is UTC. Change to be EST 

## Changes Made

- Standardize timezone across app to America/New_York
- Only return rides that have yet to happen when getting a user


## Test Coverage

Manual testing via Postman
