### PR TITLE
Fix Person ID offset locally

### DIFF
--- a/src/person/controllers/authenticate_controller.py
+++ b/src/person/controllers/authenticate_controller.py
@@ -101,6 +101,9 @@ class AuthenticateController:
             if user is None:
                 return failure_response("ID Token is not valid.", status=status_code)
         access_token = self.create_access_token(user)
+        if not Person.objects.filter(user=user):
+            person_data = {"user": user}
+            self.create_person(person_data)
         return success_response(
             self._serializer(user, context={"access_token": access_token}).data,
             status=status_code,


### PR DESCRIPTION
## Overview

The Django User ID and Person ID were offset, since creating a superuser didn't automatically create a Person object associated with the superuser.

## Changes Made

Each time a superuser logs in with /api/authenticate/, a Person object is created.

## Test Coverage

I logged in as the superuser in Postman using a post request to /api/authenticate/, then made a get request to /api/dev/ which gets all users. If a user doesn't have an associated person, there will be the error: "RelatedObjectDoesNotExist: User has no person." I also checked in the Django superuser dashboard to see if the superuser is associated with a Person object.